### PR TITLE
Fix for fence post error in Display Customer Character function

### DIFF
--- a/firmware/OpenLCD/OpenLCD.ino
+++ b/firmware/OpenLCD/OpenLCD.ino
@@ -262,8 +262,8 @@ void updateDisplay()
       modeRecordCustomChar = true; //Change to this special mode
     }
 
-    //Display custom characters
-    else if (incoming >= 35 && incoming <= 43)
+    //Display custom characters, 8 characters allowed, 35 to 42 inclusive
+    else if (incoming >= 35 && incoming <= 42)
     {
       SerLCD.write(byte(incoming - 35)); //You write location zero to display customer char 0
     }

--- a/firmware/OpenLCD/OpenLCD.ino
+++ b/firmware/OpenLCD/OpenLCD.ino
@@ -267,7 +267,14 @@ void updateDisplay()
     {
       SerLCD.write(byte(incoming - 35)); //You write location zero to display customer char 0
     }
+    //If we get a second special setting character, then write it to the display 
+    //This allows us to print a pipe by escaping it as a double 
+    else if (incoming == SPECIAL_SETTING) {
+      SerLCD.write(incoming);
 
+      currentFrame[characterCount++] = incoming; //Record this character to the display buffer
+      if (characterCount == settingLCDwidth * settingLCDlines) characterCount = 0; //Wrap condition
+    }
     modeSetting = false;
   }
   else if (modeTWI == true)


### PR DESCRIPTION
This pull request changes the if statement in file OpenLCD.ino, line 266 to be 35 to 42 inclusive.  This removes the extraneous display customer character function for a ninth (non-existent) character.

Closes #5 