### PR TITLE
Updated all references of EEPROM.write to EEPROM.update

### DIFF
--- a/firmware/OpenLCD/OpenLCD.ino
+++ b/firmware/OpenLCD/OpenLCD.ino
@@ -392,7 +392,7 @@ void updateDisplay()
 
       //Record this custom char to EEPROM
       for (byte charSpot = 0 ; charSpot < 8 ; charSpot++)
-        EEPROM.write(LOCATION_CUSTOM_CHARACTERS + (customCharNumber * 8) + charSpot, customCharData[charSpot]); //addr, val
+        EEPROM.update(LOCATION_CUSTOM_CHARACTERS + (customCharNumber * 8) + charSpot, customCharData[charSpot]); //addr, val
 
       //For some reason you need to re-init the LCD after a custom char is created
       SerLCD.begin(settingLCDwidth, settingLCDlines);

--- a/firmware/OpenLCD/Setting_Control.ino
+++ b/firmware/OpenLCD/Setting_Control.ino
@@ -26,7 +26,7 @@ void changeIgnore()
     SerLCD.print(F("N"));
   }
   //Record this new setting
-  EEPROM.write(LOCATION_IGNORE_RX, settingIgnoreRX);
+  EEPROM.update(LOCATION_IGNORE_RX, settingIgnoreRX);
 
   petSafeDelay(SYSTEM_MESSAGE_DELAY);
 
@@ -53,7 +53,7 @@ void displayFirmwareVersion()
 //Press a or z to adjust, x to exit
 void changeContrast(byte contrast)
 {
-  EEPROM.write(LOCATION_CONTRAST, contrast); //Store this new contrast
+  EEPROM.update(LOCATION_CONTRAST, contrast); //Store this new contrast
 
   //Go to this new contrast
   analogWrite(LCD_CONTRAST, contrast);
@@ -74,7 +74,7 @@ void changeContrast(byte contrast)
 void changeTWIAddress(byte newAddress)
 {
   //Record the new address
-  EEPROM.write(LOCATION_TWI_ADDRESS, newAddress);
+  EEPROM.update(LOCATION_TWI_ADDRESS, newAddress);
 
   setupTWI(); //Leverage the regular startup function
 
@@ -95,7 +95,7 @@ void changeSplashContent()
 {
   //Record the current frame to EEPROM
   for (byte x = 0 ; x < settingLCDlines * settingLCDwidth ; x++)
-    EEPROM.write(LOCATION_SPLASH_CONTENT + x, currentFrame[x]);
+    EEPROM.update(LOCATION_SPLASH_CONTENT + x, currentFrame[x]);
 
   //Display the backlight setting
   SerLCD.clear();
@@ -114,17 +114,17 @@ void changeBLBrightness(byte color, byte brightness)
 {
   if (color == RED)
   {
-    EEPROM.write(LOCATION_RED_BRIGHTNESS, brightness); //Record new setting
+    EEPROM.update(LOCATION_RED_BRIGHTNESS, brightness); //Record new setting
     analogWrite(BL_RW, 255 - brightness); //Controlled by PNP so reverse the brightness value
   }
   else if (color == GREEN)
   {
-    EEPROM.write(LOCATION_GREEN_BRIGHTNESS, brightness); //Record new setting
+    EEPROM.update(LOCATION_GREEN_BRIGHTNESS, brightness); //Record new setting
     analogWrite(BL_G, 255 - brightness); //Controlled by PNP so reverse the brightness value
   }
   else if (color == BLUE)
   {
-    EEPROM.write(LOCATION_BLUE_BRIGHTNESS, brightness); //Record new setting
+    EEPROM.update(LOCATION_BLUE_BRIGHTNESS, brightness); //Record new setting
     //analogWrite(BL_B, 255 - brightness); //Controlled by PNP so reverse the brightness value
     SoftPWMSet(BL_B, 255 - brightness); //Controlled by software PWM
   }
@@ -154,15 +154,15 @@ void changeBLBrightness(byte color, byte brightness)
 //with their rgb values to eliminate flicker. Incoming brightness values should be 0 to 255
 void changeBacklightRGB(byte red, byte green, byte blue) {
   //update red
-  EEPROM.write(LOCATION_RED_BRIGHTNESS, red); //Record new setting
+  EEPROM.update(LOCATION_RED_BRIGHTNESS, red); //Record new setting
   analogWrite(BL_RW, 255 - red); //Controlled by PNP so reverse the brightness value
 
   //update green
-  EEPROM.write(LOCATION_GREEN_BRIGHTNESS, green); //Record new setting
+  EEPROM.update(LOCATION_GREEN_BRIGHTNESS, green); //Record new setting
   analogWrite(BL_G, 255 - green); //Controlled by PNP so reverse the brightness value
 
   //update blue (SoftPWM)
-  EEPROM.write(LOCATION_BLUE_BRIGHTNESS, blue); //Record new setting
+  EEPROM.update(LOCATION_BLUE_BRIGHTNESS, blue); //Record new setting
   //analogWrite(BL_B, 255 - brightness); //Controlled by PNP so reverse the brightness value
   SoftPWMSet(BL_B, 255 - blue); //Controlled by software PWM
 }
@@ -216,7 +216,7 @@ void changeUARTSpeed(byte setting)
   }
 
   //Record this new buad rate
-  EEPROM.write(LOCATION_BAUD, settingUARTSpeed);
+  EEPROM.update(LOCATION_BAUD, settingUARTSpeed);
 
   //Display that we are at this new speed
   SerLCD.clear();
@@ -254,7 +254,7 @@ void changeSplashEnable()
   petSafeDelay(SYSTEM_MESSAGE_DELAY);
 
   //Record this new setting
-  EEPROM.write(LOCATION_SPLASH_ONOFF, settingSplashEnable);
+  EEPROM.update(LOCATION_SPLASH_ONOFF, settingSplashEnable);
 
   displayFrameBuffer(); //Return the contents of the display
 }
@@ -287,8 +287,8 @@ void changeLinesWidths(byte setting)
   clearFrameBuffer();
 
   //Record this new setting
-  EEPROM.write(LOCATION_WIDTH, settingLCDwidth);
-  EEPROM.write(LOCATION_LINES, settingLCDlines);
+  EEPROM.update(LOCATION_WIDTH, settingLCDwidth);
+  EEPROM.update(LOCATION_LINES, settingLCDlines);
 
   //Display new settings to the user
   SerLCD.clear();

--- a/firmware/OpenLCD/System_Functions.ino
+++ b/firmware/OpenLCD/System_Functions.ino
@@ -91,7 +91,7 @@ void setupUART()
   if (settingIgnoreRX > 1)
   {
     settingIgnoreRX = false; //Don't ignore
-    EEPROM.write(LOCATION_IGNORE_RX, settingIgnoreRX);
+    EEPROM.update(LOCATION_IGNORE_RX, settingIgnoreRX);
   }
 
   if (settingIgnoreRX == false) //If we are NOT ignoring RX, then
@@ -103,7 +103,7 @@ void setupUART()
   if (settingUARTSpeed > BAUD_1000000) //Check to see if the baud rate has ever been set
   {
     settingUARTSpeed = DEFAULT_BAUD; //Reset UART to 9600 if there is no baud rate stored
-    EEPROM.write(LOCATION_BAUD, settingUARTSpeed);
+    EEPROM.update(LOCATION_BAUD, settingUARTSpeed);
   }
 
   //Initialize the UART
@@ -139,7 +139,7 @@ void setupTWI()
   if ((twiAddress == 0) || (twiAddress > 0x7F))
   { // If the TWI address is invalid, use a default address
     twiAddress = DEFAULT_TWI_ADDRESS;
-    EEPROM.write(LOCATION_TWI_ADDRESS, DEFAULT_TWI_ADDRESS);
+    EEPROM.update(LOCATION_TWI_ADDRESS, DEFAULT_TWI_ADDRESS);
   }
 
   Wire.begin(twiAddress);  //Initialize Wire library as slave at twiAddress address
@@ -154,7 +154,7 @@ void setupContrast()
   if (settingContrast == 255) //Check to see if the contrast has ever been set
   {
     settingContrast = DEFAULT_CONTRAST_LCD; //Default
-    EEPROM.write(LOCATION_CONTRAST, settingContrast);
+    EEPROM.update(LOCATION_CONTRAST, settingContrast);
   }
 
   //Change contrast without notification message
@@ -171,14 +171,14 @@ void setupLCD()
   if (settingLCDlines > 4)
   {
     settingLCDlines = DEFAULT_LINES;
-    EEPROM.write(LOCATION_LINES, settingLCDlines);
+    EEPROM.update(LOCATION_LINES, settingLCDlines);
   }
 
   settingLCDwidth = EEPROM.read(LOCATION_WIDTH);
   if (settingLCDwidth > 20)
   {
     settingLCDwidth = DEFAULT_WIDTH;
-    EEPROM.write(LOCATION_WIDTH, settingLCDwidth);
+    EEPROM.update(LOCATION_WIDTH, settingLCDwidth);
   }
 
   //Check the display jumper
@@ -222,7 +222,7 @@ void setupSplash()
   if (settingSplashEnable > 1)
   {
     settingSplashEnable = DEFAULT_SPLASH;
-    EEPROM.write(LOCATION_SPLASH_ONOFF, settingSplashEnable);
+    EEPROM.update(LOCATION_SPLASH_ONOFF, settingSplashEnable);
   }
 
   if (settingSplashEnable)
@@ -246,7 +246,7 @@ void setupSplash()
       if (settingUARTSpeed > BAUD_1000000) //Check to see if the baud rate has ever been set
       {
         settingUARTSpeed = DEFAULT_BAUD; //Reset UART to 9600 if there is no baud rate stored
-        EEPROM.write(LOCATION_BAUD, settingUARTSpeed);
+        EEPROM.update(LOCATION_BAUD, settingUARTSpeed);
       }
 
       SerLCD.print(lookUpBaudRate(settingUARTSpeed));
@@ -284,7 +284,7 @@ void setupSplash()
 
           SerLCD.print("Baud Reset");
 
-          EEPROM.write(LOCATION_BAUD, BAUD_9600);
+          EEPROM.update(LOCATION_BAUD, BAUD_9600);
 
           petSafeDelay(SYSTEM_MESSAGE_DELAY);
 
@@ -352,9 +352,7 @@ void checkEmergencyReset(void)
 
   //If we make it here, then RX pin stayed low the whole time
   //Reset all EEPROM locations to factory defaults.
-  for (int x = 0 ; x < 200 ; x++)
-    EEPROM.write(x, 0xFF);
-
+  for (int x = 0 ; x < 200 ; x++) EEPROM.update(x, 0xFF);
 
   //Change contrast without notification message
   analogWrite(LCD_CONTRAST, 40); //Set contrast to default


### PR DESCRIPTION
Patch to reduce unnecessary EEPROM writes by using .update() method, which compares the current value first. The comparatively small cost of the read should be more than made up for by the reduction in writes for the majority of operations. Also since there is currently no way to read the settings back, it reduces writes where application firmware needs to set the OpenLCD to an initial state at reset.