### PR TITLE
emergency reset disabled by default

### DIFF
--- a/firmware/OpenLCD/Setting_Control.ino
+++ b/firmware/OpenLCD/Setting_Control.ino
@@ -26,7 +26,7 @@ void changeIgnore()
 
     SerLCD.print(F("Ignore RX O"));
 
-    if (settingIgnoreRX == true)
+    if (settingIgnoreRX == false)
       SerLCD.print(F("FF"));
     else
       SerLCD.print(F("N"));

--- a/firmware/OpenLCD/System_Functions.ino
+++ b/firmware/OpenLCD/System_Functions.ino
@@ -339,7 +339,6 @@ void checkEmergencyReset(void)
   pinMode(rxPin, INPUT_PULLUP); //Turn the RX pin into an input with pullups
 
   if (digitalRead(rxPin) == HIGH) return; //Quick pin check
-  SerLCD.print(rxPin);
   //Wait 2 seconds, blinking backlight while we wait
   pinMode(BL_RW, OUTPUT);
   digitalWrite(BL_RW, HIGH); //Set the STAT2 LED

--- a/firmware/OpenLCD/System_Functions.ino
+++ b/firmware/OpenLCD/System_Functions.ino
@@ -88,11 +88,6 @@ void setupUART()
 {
   //Check to see if we are ignoring the RX reset or not
   settingIgnoreRX = EEPROM.read(LOCATION_IGNORE_RX);
-  if (settingIgnoreRX > 1)
-  {
-    settingIgnoreRX = false; //Don't ignore
-    EEPROM.update(LOCATION_IGNORE_RX, settingIgnoreRX);
-  }
 
   if (settingIgnoreRX == false) //If we are NOT ignoring RX, then
     checkEmergencyReset(); //Look to see if the RX pin is being pulled low
@@ -344,7 +339,7 @@ void checkEmergencyReset(void)
   pinMode(rxPin, INPUT_PULLUP); //Turn the RX pin into an input with pullups
 
   if (digitalRead(rxPin) == HIGH) return; //Quick pin check
-
+  SerLCD.print(rxPin);
   //Wait 2 seconds, blinking backlight while we wait
   pinMode(BL_RW, OUTPUT);
   digitalWrite(BL_RW, HIGH); //Set the STAT2 LED
@@ -367,7 +362,15 @@ void checkEmergencyReset(void)
   for (int x = 0 ; x < 200 ; x++) EEPROM.update(x, 0xFF);
 
   //Change contrast without notification message
-  analogWrite(LCD_CONTRAST, 40); //Set contrast to default
+  analogWrite(LCD_CONTRAST, DEFAULT_CONTRAST_LCD); //Set contrast to default
+
+  //Force ignoreRX to false.
+  EEPROM.update(LOCATION_IGNORE_RX, false);
+
+  //Change backlight to defaults
+  changeBLBrightness(RED, DEFAULT_RED);
+  changeBLBrightness(GREEN, DEFAULT_GREEN);
+  changeBLBrightness(BLUE, DEFAULT_BLUE);
 
   SerLCD.clear();
   SerLCD.print("System reset");

--- a/firmware/OpenLCD/settings.h
+++ b/firmware/OpenLCD/settings.h
@@ -34,7 +34,9 @@
 
 const byte DEFAULT_TWI_ADDRESS = 0x72; //0x71 for Serial7Segment. 0x72 for SerLCD.
 const byte DEFAULT_BAUD = BAUD_9600;  //9600 for 8MHz, 2x speed
-const byte DEFAULT_BRIGHTNESS = 255;  //100%, full brightness
+const byte DEFAULT_RED = 255;
+const byte DEFAULT_GREEN = 255;
+const byte DEFAULT_BLUE = 255;
 const byte DEFAULT_LINES = 2;
 const byte DEFAULT_WIDTH = 16;
 const byte DEFAULT_SPLASH = true; //Default on


### PR DESCRIPTION
Improper initialization of settingIgnoreRX caused RX to be ignored by default. Probably due to it being changed from a byte to a boolean between revisions.

Also made small enhancements to brightness settings.