### PR TITLE
enable true off for blue LED

### DIFF
--- a/firmware/OpenLCD/Setting_Control.ino
+++ b/firmware/OpenLCD/Setting_Control.ino
@@ -164,7 +164,7 @@ void changeBLBrightness(byte color, byte brightness)
   {
     EEPROM.update(LOCATION_BLUE_BRIGHTNESS, brightness); //Record new setting
     //analogWrite(BL_B, 255 - brightness); //Controlled by PNP so reverse the brightness value
-    SoftPWMSet(BL_B, 255 - brightness); //Controlled by software PWM
+    SoftPWMSet(BL_B, brightness); //Controlled by software PWM. Reversed by SoftPWM
   }
 
   if (settingDisplaySystemMessages == true)
@@ -205,7 +205,7 @@ void changeBacklightRGB(byte red, byte green, byte blue) {
   //update blue (SoftPWM)
   EEPROM.update(LOCATION_BLUE_BRIGHTNESS, blue); //Record new setting
   //analogWrite(BL_B, 255 - brightness); //Controlled by PNP so reverse the brightness value
-  SoftPWMSet(BL_B, 255 - blue); //Controlled by software PWM
+  SoftPWMSet(BL_B, blue); //Controlled by software PWM. Reversed by SoftPWM
 }
 
 //Changes the baud rate setting

--- a/firmware/OpenLCD/System_Functions.ino
+++ b/firmware/OpenLCD/System_Functions.ino
@@ -217,8 +217,9 @@ void setupBacklight()
   analogWrite(BL_RW, 255 - EEPROM.read(LOCATION_RED_BRIGHTNESS));
   analogWrite(BL_G, 255 - EEPROM.read(LOCATION_GREEN_BRIGHTNESS));
 
-  SoftPWMBegin(); //Start PWM
-  SoftPWMSet(BL_B, 255 - EEPROM.read(LOCATION_BLUE_BRIGHTNESS)); //Setup this pin to be controlled with SoftPWM. Initialize to EEPROM value
+  // SoftPWM has a true off (0 is really off), but not a true on (255 is not 100% duty cycle), so invert the logic to be able to fully turn off the blue LED.
+  SoftPWMBegin(SOFTPWM_INVERTED ); //Start PWM. 
+  SoftPWMSet(BL_B, EEPROM.read(LOCATION_BLUE_BRIGHTNESS)); //Setup this pin to be controlled with SoftPWM. Initialize to EEPROM value
   SoftPWMSetFadeTime(BL_B, 0, 0); //Don't fade - go immediately to this set PWM brightness
 }
 


### PR DESCRIPTION
 SoftPWM has a true off (0 is really off), but not a true on (255 is not 100% duty cycle), so invert the logic to be able to fully turn off the blue LED.