### PR TITLE
Added support for directly controlling a SparkFun Qwiic Twist - RGB R…

### DIFF
--- a/firmware/OpenLCD/settings.h
+++ b/firmware/OpenLCD/settings.h
@@ -58,6 +58,12 @@ const byte DEFAULT_DISPLAY_SYSTEM_MESSAGES = true; //Enable messages
 #define LOCATION_DISPLAY_SYSTEM_MESSAGES 11 //8 bit
 #define LOCATION_SPLASH_CONTENT 20 //This is 4*20 or 80 bytes wide
 #define LOCATION_CUSTOM_CHARACTERS 100 //This is 8*8 or 64 bytes wide
+#define LOCATION_TWIST_STREAM 101 // 0 disables stream update of Twist information
+#define LOCATION_TWIST_RED_BRIGHTNESS 102
+#define LOCATION_TWIST_GREEN_BRIGHTNESS 103
+#define LOCATION_TWIST_BLUE_BRIGHTNESS 104
+#define LOCATION_TWIST_FOLLOW_LCD 105
+#define LOCATION_TWI_CLIENT_ADDR 106 // 255 client mode (default), <255 is host mode and i2c address of remote TWIST.
 
 //Define the various commands
 #define SPECIAL_COMMAND 254 //0xFE: The command to do special HD77480 commands
@@ -84,3 +90,8 @@ bool settingSplashEnable;
 byte settingUARTSpeed;
 bool settingIgnoreRX;
 bool settingDisplaySystemMessages; //User can turn on/off the messages that are displayed when setting (like contrast) is changed
+bool twistPresent; // indicator if twist rgb button is present.
+bool twistButtonPressed; // previous status of twist button.
+unsigned long twistPreviousMillis = 0;  
+unsigned long twistSampleDelay = 50;  
+bool enableTwistStream;


### PR DESCRIPTION
I recently had a use case for Linux with [FTDI Basic Breakout](https://www.sparkfun.com/products/15083) to control both the Sparkfun [20x4 SerLCD](https://www.sparkfun.com/products/16398) and [Twist - RGB Rotary Encoder Breakout](https://www.sparkfun.com/products/15083). I thought it would be useful for others. Having these married together, so that a single UART host can use them both seems very practical.

[Photos of the build](https://photos.app.goo.gl/NwSQ2LaEMxYaG8w69)

### Added support for directly controlling a Sparkfun  [Twist - RGB Rotary Encoder Breakout](https://www.sparkfun.com/products/15083)
New feature to set serLCD TWI mode as host, allowing Twist to be directly polled by serLCD.
Useful when the serLCD is controlled by a host's UART. 
Example: a python script on a PC using a Basic Breakout, where the Qwiic is directly connected between the serLCD and the Twist.

New Command codes. 
```
50 Enables the twist streaming. Any Twist change prints the event.
51 Disables the twist streaming
52 Polls the Twist rotatory position counter as a text signed integer
53 Polls the Twist Button as a text message.
54 followed by R, G and B bytes to Twist LED under dial.
55 Set Twist RGB to follow LCD RGB.
56 Set Twist RGB NOT to follow LCD RGB.
57 Set TWI client/host mode and when host mode set remote client i2c TWIST address
```

Notes:

1. Twist polled or polling output is only UART supported at this time. 
2. i2c does not make sense, as serLCD would be client and the host can poll both serLCD and TWIST.
3. Backward compatible as original mode is supported by default EEprom values of 0xFF.

Future work: 
1. SPI client mode to respond twist polls. This would require a write read response, and there is no existing framework for that yet.
2. Additional Twists. 
